### PR TITLE
reviewed string actions

### DIFF
--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CBase64Decode.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CBase64Decode.java
@@ -39,11 +39,11 @@ import java.util.List;
 
 /**
  * action to decodes a string with Base64.
- * Creates from each string argument, which is
- * based64 encoded the decoded string version,
- * the action never fails
+ * The decoded string version is created from each string argument, which is
+ * based64 encoded.
+ * The action never fails.
  *
- * @code [A|B] = generic/string/base64decode( "aGVsbG8=", "QWdlbnRTcGVhayhMKysp" ); @endcode
+ * @code [A|B] = string/base64decode( "aGVsbG8=", "QWdlbnRTcGVhayhMKysp" ); @endcode
  * @note return null on encoding errors
  * @see https://en.wikipedia.org/wiki/Base64
  */

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CBase64Encode.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CBase64Encode.java
@@ -38,10 +38,9 @@ import java.util.List;
 
 /**
  * action to encodes a string with Base64.
- * Creates from each string argument the base64 encoded
- * version, the action fails on encoding errors
- *
- * @code [A|B] = generic/string/base64encode( "Hello", "AgentSpeak(L++)" ); @endcode
+ * The base64 encoded version is created from each string argument.
+ * The action fails on encoding errors.
+ * @code [A|B] = string/base64encode( "Hello", "AgentSpeak(L++)" ); @endcode
  * @see https://en.wikipedia.org/wiki/Base64
  */
 public final class CBase64Encode extends IBuildinAction

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CConcat.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CConcat.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * All string arguments will be join to a single
  * result, the action never fails
  *
- * @code S = generic/string/concat("A", "B", "C"); @endcode
+ * @code S = string/concat("A", "B", "C"); @endcode
  */
 public final class CConcat extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CContains.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CContains.java
@@ -40,7 +40,7 @@ import java.util.List;
  * all other arguments, but it returns the boolean result for
  * each argument, the action never fails
  *
- * @code [L1|L2] = generic/string/contains("this is a long string", "long", "string"); @endcode
+ * @code [L1|L2] = string/contains("this is a long string", "long", "string"); @endcode
  */
 public final class CContains extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CEndsWith.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CEndsWith.java
@@ -40,7 +40,7 @@ import java.util.List;
  * with each other arguments for the operation ends-with,
  * the action never fails
  *
- * @code [L1|L2] = generic/string/endswith("this is a long string", "long string", "string"); @endcode
+ * @code [L1|L2] = string/endswith("this is a long string", "long string", "string"); @endcode
  */
 public final class CEndsWith extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CLower.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CLower.java
@@ -39,7 +39,7 @@ import java.util.List;
  * All arguments of the action will change
  * to a lower-case string and the action never fails
  *
- * @code [A|B|C|D] = generic/string/lower("AbC", "Ef", ["de", "XyZ"]); @endcode
+ * @code [A|B|C|D] = string/lower("AbC", "Ef", ["de", "XyZ"]); @endcode
  */
 public final class CLower extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CNCD.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CNCD.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * string, if the first argument matches a compression algorithm ( BZIP |
  * GZIP | DEFLATE | PACK200 | XZ ), it will be used for defining the compression,
  * the next string argument will be the input string and the distances will be
- * calculated between the first and all other arguments, the action fails on wrong input
+ * calculated between the second and all other arguments, the action fails on wrong input
  *
  * @code [A|B] = string/ncd( "BZIP|GZIP|DEFLATE|PACK200|XZ", "foo bar", "test foo", "bar foo" ); @endcode
  * @see https://en.wikipedia.org/wiki/Normalized_compression_distance

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CRandom.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CRandom.java
@@ -41,7 +41,7 @@ import java.util.List;
  * all other arguments are numbers to present the length of the returning string
  * and the action never fails
  *
- * @code [A|B|C] = generic/string/random( "abdefgXYZUI", 5, 3, 6 ); @endcode
+ * @code [A|B|C] = string/random( "abdefgXYZUI", 5, 3, 6 ); @endcode
  */
 public final class CRandom extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CReverse.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CReverse.java
@@ -39,7 +39,7 @@ import java.util.List;
  * The action reverse each argument string and returns
  * the reversed string, the action never fails
  *
- * @code [A|B|C] = generic/string/reverse("Foo Bar", ["ABBA", "Eevee"]); @endcode
+ * @code [A|B|C] = string/reverse("Foo Bar", ["ABBA", "Eevee"]); @endcode
  */
 public final class CReverse extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CSize.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CSize.java
@@ -39,7 +39,7 @@ import java.util.List;
  * For each argument the string length will be returned
  * and the action never fails
  *
- * @code [A|B|C] = generic/string/size("A", ["CC", "XYZ"]); @endcode
+ * @code [A|B|C] = string/size("A", ["CC", "XYZ"]); @endcode
  */
 public final class CSize extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CStartsWith.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CStartsWith.java
@@ -40,7 +40,7 @@ import java.util.List;
  * with each other arguments for the operation starts-with,
  * the action never fails
  *
- * @code [L1|L2] = generic/string/startswith("this is a long string", "long string", "string"); @endcode
+ * @code [L1|L2] = string/startswith("this is a long string", "long string", "string"); @endcode
  */
 public final class CStartsWith extends IBuildinAction
 {

--- a/src/main/java/org/lightjason/agentspeak/action/buildin/string/CUpper.java
+++ b/src/main/java/org/lightjason/agentspeak/action/buildin/string/CUpper.java
@@ -39,7 +39,7 @@ import java.util.List;
  * All arguments of the action will change
  * to a upper-case string and the action never fails
  *
- * @code [A|B|C|D] = generic/string/upper("AbC", "Ef", ["de", "XYZ"]); @endcode
+ * @code [A|B|C|D] = string/upper("AbC", "Ef", ["de", "XYZ"]); @endcode
  */
 public final class CUpper extends IBuildinAction
 {


### PR DESCRIPTION
From my point of view, the following example: 
[A|B] = string/ncd( "BZIP|GZIP|DEFLATE|PACK200|XZ", "foo bar", "test foo", "bar foo" ); 

could written as:
[A|B] = string/ncd( "BZIP", "foo bar", "test foo", "bar foo" ); 

Run with individual compression algorithm, works correctly. But 
[A|B] = string/ncd( "XZ", "foo bar", "test foo", "bar foo" ); 
Shows error.

Did not change this things within ncd action, as I am not sure.

